### PR TITLE
BANNO.NEWSUBCREATE.V1.CONFIG HTML Update

### DIFF
--- a/open-subshare/README.md
+++ b/open-subshare/README.md
@@ -1,24 +1,32 @@
 # Open a Subshare
-The Open a Subshare PowerOn allows the end-user to open a subshares whenever it’s convenient for them. While creating their new subshare, the members can easily add additional names associated with the subshare and add funds to their new account via transfer. 
+The Open a Subshare PowerOn allows the end-user to open a subshares whenever it’s convenient for them. While creating their new subshare, the members can easily add additional names associated 
+with the subshare and add funds to their new account via transfer.
 
-Account types included (but not limited to): 
+Account types included (but not limited to):
 * Certificate of deposit
 * Checking
 * Club
-* Savings 
+* Savings
 * Money market
 
-Included in the PowerOn files is a configuration tool (BANNO.NEWSUBCREATE.V1.CONFIG) which is an on-demand PowerOn, to be run from the Account Manager, which helps you customize the PowerOn to your needs. The tool will generate a configuration datafile used by the program.
+Included in the PowerOn files is a configuration tool (BANNO.NEWSUBCREATE.V1.CONFIG) which is an on-demand PowerOn, to be run from the Account Manager, which helps you customize the PowerOn to 
+your needs. The tool will generate a configuration datafile used by the program.
 
 ## Required files
 * PowerOn Name: BANNO.NEWSUBCREATE.V1.POW
 * Configuration PowerOn: BANNO.NEWSUBCREATE.V1.CONFIG
 
 ## Setup Steps
-In addition to the normal setup process for the PowerOn program, 
+In addition to the normal setup process for the PowerOn program,
 * Run the configuration program (BANNO.NEWSUBCREATE.V1.CONFIG) from the Account Manager. The program contains a built-in help file explaining each setting and how it can be used.
 	* The configuration program saves your desired options to a datafile which is used by the PowerOn program at run-time
-	* The configuration program also creates, as necessary, Terms or Conditions Letterfiles which can be updated as needed for each of the share groups you're making available for members to select from.
+	* The configuration program also creates, as necessary, Terms or Conditions (TOC) Letter files which can be updated as needed for each of the share groups you're making available for members to 
+ select from. When updating the TOC Letter files...
+		* Keep each line to 120 characters or less
+		* Avoid the use of special characters and double-quotes
+		* You can include the following HTML tags to customize the formatting to suit your needs:
+			* `<h1>, <h2>, <h3>, <h4>, <h5>, <h6>, <b>, <strong>, <i>, <u>, <ul>, <ol>, <li>, <br>, <p>, <a> and <hr>`.
+		* For backwards compatibility, a single blank line will be interpreted as a new line and two blank lines in a row will be interpreted as a new paragraph.
 
 ## Supported SymXchange web consoles:
 * PowerOnService - 2017.01 V1

--- a/open-subshare/REPWRITERSPECS/BANNO.NEWSUBCREATE.V1.CONFIG
+++ b/open-subshare/REPWRITERSPECS/BANNO.NEWSUBCREATE.V1.CONFIG
@@ -3,12 +3,15 @@
 **  Letterfile Name:    BANNO.NEWSUBCREATE.V1.CFG
 **                      BANNO.NEWSUBCREATE.TERMS.00-09
 **
-**  Copyright 2020 Jack Henry and Associates
+**  Copyright 2020-2022 Jack Henry and Associates
 **
 **  05/18/2020: Initial program creation
 **  12/17/2020: TKainz: Added check for share having a defined
 **              dividend type. If undefined, share type is not
 **              eligible for selection.
+**  04/05/2022: TKainz: Updated sample text and instructions in
+**              BANNO.NEWSUBCREATE.TERMS.xx Letter files to include
+**              the ability to use basic HTML commands.
 **
 **  This Banno service PowerOn is to be installed for use on
 **  demand and is run from the Account Manager workspace to
@@ -1140,14 +1143,44 @@ PROCEDURE CREATETOCLETTERFILES
    IF SACSHARETYPEGROUPNAMES(GROUPLOOP)<>"" THEN
     DO
      TMPCHR=FORMAT("BANNO.NEWSUBACCT.TERMS.99",GROUPLOOP)
+[* Attempt to open file to write. Fails if file already exists
+*]
      FILEOPEN("LETTER",TMPCHR,"WRITE",FILENUMBER,FILEERROR)
      IF FILEERROR="" THEN
       DO
        FILEWRITELINE(FILENUMBER,"Sample Terms for Banno Sub Acct Opening",FILEERROR)
        FILEWRITELINE(FILENUMBER,"",FILEERROR)
-       FILEWRITELINE(FILENUMBER,"Certificates Shares...",FILEERROR)
-       FILEWRITELINE(FILENUMBER,"Condition 1:",FILEERROR)
-       FILEWRITELINE(FILENUMBER,"Condition 2:",FILEERROR)
+       FILEWRITELINE(FILENUMBER,"",FILEERROR)
+       FILEWRITELINE(FILENUMBER,"Data will be displayed as written. The following HTML tags may be"+
+                                " utilized to facilitate text formatting:",FILEERROR)
+       FILEWRITELINE(FILENUMBER,"    h1, h2, h3, h4, h5, h6, b, strong, i, u, ul, ol, li, br, p, a "+
+                                "and hr.",FILEERROR)
+       FILEWRITELINE(FILENUMBER,"Of course... don't forget to include them in their required delimiters '<>'. "+
+                                "Avoid the use of double quotes",FILEERROR)
+       FILEWRITELINE(FILENUMBER,"or special characters in your message.",FILEERROR)
+       FILEWRITELINE(FILENUMBER,"",FILEERROR)
+       FILEWRITELINE(FILENUMBER,"",FILEERROR)
+       FILEWRITELINE(FILENUMBER,"For backwards compatibility, a single blank line will be interpreted as a "+
+                                "new line and two blank lines in a row",FILEERROR)
+       FILEWRITELINE(FILENUMBER,"will be interpreted as a new paragraph",FILEERROR) 
+       FILEWRITELINE(FILENUMBER,"",FILEERROR)
+       FILEWRITELINE(FILENUMBER,"",FILEERROR)
+       FILEWRITELINE(FILENUMBER,"Use this ruler as a guideline when setting up your messages. Do not extend "+
+                                "past the end of this line (120 characters).",FILEERROR)
+       FILEWRITELINE(FILENUMBER,"",FILEERROR)
+       FILEWRITELINE(FILENUMBER,"",FILEERROR)
+       FILEWRITELINE(FILENUMBER,"         10        20        30        40        50        60        70        "+
+                                "80        90        100       110       120",FILEERROR)
+       FILEWRITELINE(FILENUMBER,"12345678901234567890123456789012345678901234567890123456789012345678901234567890"+
+                                "1234567890123456789012345678901234567890",FILEERROR)
+       FILEWRITELINE(FILENUMBER,"---------|---------|---------|---------|---------|---------|---------|---------|"+
+                                "---------|---------|---------|---------|",FILEERROR)
+       FILEWRITELINE(FILENUMBER,"",FILEERROR)
+       FILEWRITELINE(FILENUMBER,"<h3>Savings Shares</h3>",FILEERROR)
+       FILEWRITELINE(FILENUMBER,"<ul>",FILEERROR)
+       FILEWRITELINE(FILENUMBER,"<li>Condition 1</li>",FILEERROR)
+       FILEWRITELINE(FILENUMBER,"<li>Condition 2</li>",FILEERROR)
+       FILEWRITELINE(FILENUMBER,"</ul>",FILEERROR)
        FILEWRITELINE(FILENUMBER,"",FILEERROR)
 
        IF FILEERROR="" THEN
@@ -1356,4 +1389,3 @@ PROCEDURE LOADNTSUBACCTCONFIG
   END
  FILECLOSE(SACFILENUM,SACFILEERROR)
 END [PROCEDURE]
-


### PR DESCRIPTION
Updated to add additional information to the template Terms Letter files when they are created by the program. The new Template terms Letter files created by the program (as needed) will appear as follows
```
Sample Terms for Banno Sub Acct Opening


Data will be displayed as written. The following HTML tags may be utilized to facilitate text formatting:
    h1, h2, h3, h4, h5, h6, b, strong, i, u, ul, ol, li, br, p, a and hr.
Of course... don't forget to include them in their required delimiters '<>'. Avoid the use of double quotes
or special characters in your message.


For backwards compatibility, a single blank line will be interpreted as a new line and two blank lines in a row
will be interpreted as a new paragraph


Use this ruler as a guideline when setting up your messages. Do not extend past the end of this line (120 characters).


         10        20        30        40        50        60        70        80        90        100       110       120
123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890
---------|---------|---------|---------|---------|---------|---------|---------|---------|---------|---------|---------|

<h3>Savings Shares</h3>
<ul>
<li>Condition 1</li>
<li>Condition 2</li>
</ul>
```
