### PR TITLE
fix to subshare config and test account input

### DIFF
--- a/open-subshare/REPWRITERSPECS/BANNO.NEWSUBCREATE.V1.CONFIG
+++ b/open-subshare/REPWRITERSPECS/BANNO.NEWSUBCREATE.V1.CONFIG
@@ -37,6 +37,9 @@
 **              specfile.
 **              2. New fee support via BANNO.NEWSUBCREATE.FEES.V1.POW
 **              3. Added support for three new error codes (512, 513 and 514).
+**  Ver. 1.2.1  03/02/2023: RRobison
+**              Fixed bug with test account input.  Code was not saving more than 6 test accounts
+**              when entered in the Test Accounts field.
 **
 **  This Banno service PowerOn is to be installed for use on
 **  demand and is run from the Account Manager workspace to
@@ -1176,8 +1179,8 @@ PROCEDURE DISPLAYHTML
 
  HTMLVIEWLINE("<td class='lbl width300'>Test accounts list:</td>")
  HTMLVIEWLINE("<td>")
- HTMLVIEWLINE("<input id='testModeAccountList' class='width600' type='text' value='"+
-  SACTESTMODEACCOUNTLIST+"' ")
+ HTMLVIEWLINE("<input id='testModeAccountList' class='width600' type='text'")
+ HTMLVIEWLINE(" value='"+SACTESTMODEACCOUNTLIST+"' ")
  HTMLVIEWLINE("/>")
  HTMLVIEWLINE("</td></tr>")
 

--- a/open-subshare/REPWRITERSPECS/BANNO.NEWSUBCREATE.V1.CONFIG
+++ b/open-subshare/REPWRITERSPECS/BANNO.NEWSUBCREATE.V1.CONFIG
@@ -1179,7 +1179,7 @@ PROCEDURE DISPLAYHTML
 
  HTMLVIEWLINE("<td class='lbl width300'>Test accounts list:</td>")
  HTMLVIEWLINE("<td>")
- HTMLVIEWLINE("<input id='testModeAccountList' class='width600' type='text'")
+ HTMLVIEWLINE("<input id='testModeAccountList' class='width600' type='text' maxlength='109'")
  HTMLVIEWLINE(" value='"+SACTESTMODEACCOUNTLIST+"' ")
  HTMLVIEWLINE("/>")
  HTMLVIEWLINE("</td></tr>")


### PR DESCRIPTION
With more than 5 test accounts the <input> line exceeded the 132 char maximum resulting in invalid html.  Trying to add a new test account would fail -- likely due to the broken html on the input.