### PR TITLE
Updated error codes in JSon contract for BANNO ODT Opt-In and Improved JSon error message detail for configuration file validation error

### DIFF
--- a/odt-opt-in/ODT Opt-in JSON Contract.md
+++ b/odt-opt-in/ODT Opt-in JSON Contract.md
@@ -173,16 +173,25 @@ UX returns updated state of each share. Share IDs listed are to be enrolled into
 
 ## Error Codes
 
-| Error Code | Logging Error Message                                     |
-| ---------- | --------------------------------------------------------- |
-| 501        | Config file read error: _[read error]_                    |
-| 502        | Config file validation error: _[validation error detail]_ |
-| 503        | No eligible shares                                        |
-| 504        | Ineligible account type                                   |
-| 505        | Account warning found                                     |
-| 506        | Error attempting to update share tracking record          |
-| 507        | Error updating source code and auth & fee fields          |
-| 508        | Error updating share overdraft tolerance amount           |
+*See the Modifier section for additional details.
+ The Modifier is appended to the main Logging Error Message.
+
+| Error Code | Logging Error Message                                                                 | Modifier                                                                             | Additional Notes As Needed                    |
+| ---------- | ------------------------------------------------------------------------------------- |------------------------------------------------------------------------------------- |-----------------------------------------------|
+| 500        | Program running in memo mode |||
+| 501        | Error reading from config file | :Error Opening Letterfile [configuration file name]: [system generated letter file read error message] ||
+|            || :Error Reading Letterfile [configuration file name]: [system generated letter file read error message] ||
+| 502        | Config file validation error | :Invalid tracking type||
+|            || :Invalid source code for SCT in CFG | In the CFG for SCT (source code 1 value if opt-in = true) there is an invalid value. Remove the value from the CFG not listed as valid in CFG comments. |
+|            || :Invalid source code for SCF in CFG | In the CFG for SCF (source code 1 value if opt-in = false) there is an invalid value. Remove the value from the CFG not listed as valid in CFG comments. |
+|            || :Invalid auth/fee option for AFT in CFG | In the CFG for AFT (Auth & fee 1 value if opt-in = true) there is an invalid value. Remove the value from the CFG not listed as valid in CFG comments. |
+|            || :Invalid auth/fee option for AFF in CFG | In the CFG for AFF (Auth & fee 1 value if opt-in = false) there is an invalid value. Remove the value from the CFG not listed as valid in CFG comments. |
+| 503        | No eligible shares. |||
+| 504        | Ineligible Acct Type 1234 found |||
+| 505        | Account warning 123 exists |||
+| 506        | Error attempting to update share tracking | : [file maintenance system error message] ||
+| 507        | Error updating source code & auth/fee fields | : [file maintenance system error message] ||
+| 508        | Error updating share overdraft tolerance amount | : [file maintenance system error message] ||
 
 - Individual error codes are for ease of researching issues.
 - All error codes except for '503' will be returned to the UX as '500'

--- a/odt-opt-in/ODT Opt-in JSON Contract.md
+++ b/odt-opt-in/ODT Opt-in JSON Contract.md
@@ -179,19 +179,19 @@ UX returns updated state of each share. Share IDs listed are to be enrolled into
 | Error Code | Logging Error Message                                                                 | Modifier                                                                             | Additional Notes As Needed                    |
 | ---------- | ------------------------------------------------------------------------------------- |------------------------------------------------------------------------------------- |-----------------------------------------------|
 | 500        | Program running in memo mode |||
-| 501        | Error reading from config file | :Error Opening Letterfile [configuration file name]: [system generated letter file read error message] ||
-|            || :Error Reading Letterfile [configuration file name]: [system generated letter file read error message] ||
-| 502        | Config file validation error | :Invalid tracking type||
+|            | Error Opening Letterfile [configuration file name] | : [system generated letter file read error message] ||
+|            | Error Reading Letterfile [configuration file name] | : [system generated letter file read error message] ||
+|            | Config file validation error | :Invalid tracking type ||
 |            || :Invalid source code for SCT in CFG | In the CFG for SCT (source code 1 value if opt-in = true) there is an invalid value. See CFG comments for valid values. |
 |            || :Invalid source code for SCF in CFG | In the CFG for SCF (source code 1 value if opt-in = false) there is an invalid value. See CFG comments for valid values. |
 |            || :Invalid auth/fee option for AFT in CFG | In the CFG for AFT (Auth & fee 1 value if opt-in = true) there is an invalid value. See CFG comments for valid values. |
 |            || :Invalid auth/fee option for AFF in CFG | In the CFG for AFF (Auth & fee 1 value if opt-in = false) there is an invalid value. See CFG comments for valid values. |
+|            | Ineligible Acct Type 1234 found |||
+|            | Account warning 123 exists |||
+|            | Error attempting to update share tracking | : [file maintenance system error message] ||
+|            | Error updating source code & auth/fee fields | : [file maintenance system error message] ||
+|            | Error updating share overdraft tolerance amount | : [file maintenance system error message] ||
 | 503        | No eligible shares. |||
-| 504        | Ineligible Acct Type 1234 found |||
-| 505        | Account warning 123 exists |||
-| 506        | Error attempting to update share tracking | : [file maintenance system error message] ||
-| 507        | Error updating source code & auth/fee fields | : [file maintenance system error message] ||
-| 508        | Error updating share overdraft tolerance amount | : [file maintenance system error message] ||
 
 - Individual error codes are for ease of researching issues.
 - All error codes except for '503' will be returned to the UX as '500'

--- a/odt-opt-in/ODT Opt-in JSON Contract.md
+++ b/odt-opt-in/ODT Opt-in JSON Contract.md
@@ -182,10 +182,10 @@ UX returns updated state of each share. Share IDs listed are to be enrolled into
 | 501        | Error reading from config file | :Error Opening Letterfile [configuration file name]: [system generated letter file read error message] ||
 |            || :Error Reading Letterfile [configuration file name]: [system generated letter file read error message] ||
 | 502        | Config file validation error | :Invalid tracking type||
-|            || :Invalid source code for SCT in CFG | In the CFG for SCT (source code 1 value if opt-in = true) there is an invalid value. Remove the value from the CFG not listed as valid in CFG comments. |
-|            || :Invalid source code for SCF in CFG | In the CFG for SCF (source code 1 value if opt-in = false) there is an invalid value. Remove the value from the CFG not listed as valid in CFG comments. |
-|            || :Invalid auth/fee option for AFT in CFG | In the CFG for AFT (Auth & fee 1 value if opt-in = true) there is an invalid value. Remove the value from the CFG not listed as valid in CFG comments. |
-|            || :Invalid auth/fee option for AFF in CFG | In the CFG for AFF (Auth & fee 1 value if opt-in = false) there is an invalid value. Remove the value from the CFG not listed as valid in CFG comments. |
+|            || :Invalid source code for SCT in CFG | In the CFG for SCT (source code 1 value if opt-in = true) there is an invalid value. See CFG comments for valid values. |
+|            || :Invalid source code for SCF in CFG | In the CFG for SCF (source code 1 value if opt-in = false) there is an invalid value. See CFG comments for valid values. |
+|            || :Invalid auth/fee option for AFT in CFG | In the CFG for AFT (Auth & fee 1 value if opt-in = true) there is an invalid value. See CFG comments for valid values. |
+|            || :Invalid auth/fee option for AFF in CFG | In the CFG for AFF (Auth & fee 1 value if opt-in = false) there is an invalid value. See CFG comments for valid values. |
 | 503        | No eligible shares. |||
 | 504        | Ineligible Acct Type 1234 found |||
 | 505        | Account warning 123 exists |||

--- a/odt-opt-in/REPWRITERSPECS/BANNO.ODTOPTIN.V1.POW
+++ b/odt-opt-in/REPWRITERSPECS/BANNO.ODTOPTIN.V1.POW
@@ -1213,7 +1213,7 @@ PROCEDURE ERRORHANDLER
 *]
  ERRORMSG="loggingErrorMessage"
  ERRORDETAIL(0)="Program running in memo mode"
- ERRORDETAIL(1)="Error reading from config file: "+READCONFIGERRORMSG
+ ERRORDETAIL(1)=READCONFIGERRORMSG
  ERRORDETAIL(2)="Config file validation error: "+PARAMVALIDATIONERRORCHR
  ERRORDETAIL(3)="No eligible shares."
  ERRORDETAIL(4)=FORMAT("Ineligible Acct Type 9999 found",ACCOUNT:TYPE)

--- a/odt-opt-in/REPWRITERSPECS/BANNO.ODTOPTIN.V1.POW
+++ b/odt-opt-in/REPWRITERSPECS/BANNO.ODTOPTIN.V1.POW
@@ -27,7 +27,7 @@
 **    Ver. 1.1.1  08/09/23 T. Kainz - Corrected faulty JSON when debug mode is turned on
 **                         Added additional debug output to facilitate troubleshooting.
 **                         Corrected S/L type calc/reference.
-**    Ver. 1.1.2  01/18/24 J. Keenan - Improved JSon error message detail for
+**    Ver. 1.1.2  01/22/24 J. Keenan - Improved JSon error message detail for
 **                         configuration file validation error.
 **
 **  DO NOT MODIFY THIS FILE UNLESS YOU KNOW WHAT YOU'RE DOING!
@@ -192,7 +192,7 @@ END [DEFINE]
 SETUP
  PROGRAMNAME="BANNO.ODTOPTIN.V1.POW"
  PROGRAMVERSION="1.1.2"
- LASTMODDATE='01/18/24'
+ LASTMODDATE='01/22/24'
  LASTMODTIME="12:00 PT"
 
  Q=CTRLCHR(34)

--- a/odt-opt-in/REPWRITERSPECS/BANNO.ODTOPTIN.V1.POW
+++ b/odt-opt-in/REPWRITERSPECS/BANNO.ODTOPTIN.V1.POW
@@ -2,7 +2,7 @@
 **  PowerOn Name:       BANNO.ODTOPTIN.V1.POW
 **  Letterfile Name:    BANNO.ODTOPTIN.V1.CFG
 **
-**  Copyright 2020-2023 Jack Henry and Associates
+**  Copyright 2020-2024 Jack Henry and Associates
 **
 **  This Banno service PowerOn allows the user to Opt-In or Opt-out
 **  of the Reg-E overdraft service
@@ -27,6 +27,8 @@
 **    Ver. 1.1.1  08/09/23 T. Kainz - Corrected faulty JSON when debug mode is turned on
 **                         Added additional debug output to facilitate troubleshooting.
 **                         Corrected S/L type calc/reference.
+**    Ver. 1.1.2  01/18/24 J. Keenan - Improved JSon error message detail for
+**                         configuration file validation error.
 **
 **  DO NOT MODIFY THIS FILE UNLESS YOU KNOW WHAT YOU'RE DOING!
 *]
@@ -189,9 +191,9 @@ END [DEFINE]
 
 SETUP
  PROGRAMNAME="BANNO.ODTOPTIN.V1.POW"
- PROGRAMVERSION="1.1.1"
- LASTMODDATE='08/04/23'
- LASTMODTIME="12:30 MT"
+ PROGRAMVERSION="1.1.2"
+ LASTMODDATE='01/18/24'
+ LASTMODTIME="12:00 PT"
 
  Q=CTRLCHR(34)
  BACKSLASH=CTRLCHR(92)
@@ -965,7 +967,7 @@ PROCEDURE VALIDATEPARAMS
      IF CHARACTERSEARCH(VALIDSOURCECODELIST,TMPCHR)=0 THEN
       DO
        PARAMVALIDATIONERROR=TRUE
-       PARAMVALIDATIONERRORCHR="Invalid source code"
+       PARAMVALIDATIONERRORCHR="Invalid source code for SCT in CFG"
        TMPLOOP=LENGTH(PARAMSC1TRUE)
       END
     END
@@ -981,7 +983,7 @@ PROCEDURE VALIDATEPARAMS
      IF CHARACTERSEARCH(VALIDSOURCECODELIST,TMPCHR)=0 THEN
       DO
        PARAMVALIDATIONERROR=TRUE
-       PARAMVALIDATIONERRORCHR="Invalid tracking type"
+       PARAMVALIDATIONERRORCHR="Invalid source code for SCF in CFG"
        TMPLOOP=LENGTH(PARAMSC1FALSE)
       END
     END
@@ -991,17 +993,19 @@ PROCEDURE VALIDATEPARAMS
     PARAMUPDATEANDF=TRUE AND
    (PARAMAF1TRUE<0 OR
     PARAMAF1TRUE>7) THEN
-  PARAMVALIDATIONERROR=TRUE
+  DO
+   PARAMVALIDATIONERROR=TRUE
+   PARAMVALIDATIONERRORCHR="Invalid auth/fee option for AFT in CFG"
+  END
 
  IF PARAMVALIDATIONERROR=FALSE AND
     PARAMUPDATEANDF=TRUE AND
    (PARAMAF1FALSE<0 OR
     PARAMAF1FALSE>7) THEN
-  PARAMVALIDATIONERROR=TRUE
-
- IF PARAMSHARETRACKING<30 OR
-    PARAMSHARETRACKING>99 THEN
-  PARAMVALIDATIONERROR=TRUE
+  DO
+   PARAMVALIDATIONERROR=TRUE
+   PARAMVALIDATIONERRORCHR="Invalid auth/fee option for AFF in CFG"
+  END
 
  IF PARAMVALIDATIONERROR=TRUE THEN
   DO
@@ -1209,13 +1213,13 @@ PROCEDURE ERRORHANDLER
 *]
  ERRORMSG="loggingErrorMessage"
  ERRORDETAIL(0)="Program running in memo mode"
- ERRORDETAIL(1)="Error reading from config file:"+LFERROR
- ERRORDETAIL(2)="Config file validation error"
+ ERRORDETAIL(1)="Error reading from config file: "+READCONFIGERRORMSG
+ ERRORDETAIL(2)="Config file validation error: "+PARAMVALIDATIONERRORCHR
  ERRORDETAIL(3)="No eligible shares."
  ERRORDETAIL(4)=FORMAT("Ineligible Acct Type 9999 found",ACCOUNT:TYPE)
  ERRORDETAIL(5)=FORMAT("Account warning 999 exists",SLAWARNINGFOUND)
  ERRORDETAIL(6)="Error attempting to update share tracking: "+FMERROR
- ERRORDETAIL(7)="Error updating sourcecode & auth/fee fields: "+FMERROR
+ ERRORDETAIL(7)="Error updating source code & auth/fee fields: "+FMERROR
  ERRORDETAIL(8)="Error updating share overdraft tolerance amount: "+FMERROR
 
  ERRORDETAILOFFSET=ERRORCODE-500


### PR DESCRIPTION
Updated error codes in JSon contract for BANNO ODT Opt-In and Improved JSon error message detail for configuration file validation error. Tested briefly in SYM 900 to make sure error messages worked; then put back current version of PO in SYM 900.

[JIRA CUS-2900](https://banno-jha.atlassian.net/browse/CUS-2900)