### PR TITLE
Banno M2M Transfer

### DIFF
--- a/m2m-transfers/V3/REPWRITERSPECS/BANNO.M2MTRANSFERS.V3.POW
+++ b/m2m-transfers/V3/REPWRITERSPECS/BANNO.M2MTRANSFERS.V3.POW
@@ -90,7 +90,9 @@
 **               * Modified displayed description of recipient S/L when existing transfer
 **                 references a saved account with an external account record which has
 **                 been expired or deleted.
-**
+**   Ver. 3.2.6  12/11/2024 T. Kainz - Banno
+**               * Corrected issue where program was erring when no transfer record FM
+**                 history was found indicating the record creation date
 **
 **  DO NOT MODIFY THIS FILE UNLESS YOU KNOW WHAT YOU'RE DOING!
 *]
@@ -1167,7 +1169,7 @@ PROCEDURE FINDTRANCREATEDATE
 **  RETURN TRANSFERCREATEDATE         Record created date
 *]
  TRANSFERCREATEDATE=DATENULL
- TRANSFERCREATEUSER=-1
+ TRANSFERCREATEUSER=9999
  TRANCREATEDATEFOUND=FALSE
 
  FOR ACCOUNT ACCOUNT:NUMBER

--- a/m2m-transfers/V3/REPWRITERSPECS/BANNO.M2MTRANSFERS.V3.POW
+++ b/m2m-transfers/V3/REPWRITERSPECS/BANNO.M2MTRANSFERS.V3.POW
@@ -393,10 +393,10 @@ END [DEFINE]
 SETUP
  INCLUDEPROGRAMINFO        = TRUE
  PROGRAMVERSION            = "3.2.5"
- LASTMODDATE               = '10/28/2024'
- LASTMODTIME               = "11:00 MT"
- PROGRAMUPDATENOTE1        = "Modified recip share/loan description when referencing"
- PROGRAMUPDATENOTE2        = "deleted or expired saved ext. acct."
+ LASTMODDATE               = '12/11/2024'
+ LASTMODTIME               = "13:20 MST"
+ PROGRAMUPDATENOTE1        = "Corrected array index error when searching FM history"
+ PROGRAMUPDATENOTE2        = "for share transfer creation date when date not found"
 
  TRANRECIPTYPECHR(0)       = "savings"
  TRANRECIPTYPECHR(1)       = "checking"


### PR DESCRIPTION
Should FM history have been purged and the program is unable to determine the creation date of the share transfer record, an array out of bounds condition was occurring due to the assigned variable being used for the array index having been initialized to -1.  Program was updated to initialize the TRANSFERCREATEUSER variable to 9999 instead of -1