### PR TITLE
BANNO.NEWSUBCREATE.V1.POW Fixed rate fix

### DIFF
--- a/open-subshare/REPWRITERSPECS/BANNO.NEWSUBCREATE.V1.POW
+++ b/open-subshare/REPWRITERSPECS/BANNO.NEWSUBCREATE.V1.POW
@@ -5,7 +5,7 @@
 **  Letterfile Name:          BANNO.NEWSUBCREATE.FEEDISC.00-19
 **  Fee Display PowerOn Name: BANNO.NEWSUBCREATE.FEES.V1.POW (template)
 **
-**  Copyright 2020-2024 Jack Henry and Associates
+**  Copyright 2020-2025 Jack Henry and Associates
 **
 **  Ver. 1.0.0  08/19/2020: Added debug mode switch. When on, config file
 **              resides in LETTTERSPECS else in DATAFILES dir.
@@ -77,7 +77,7 @@
 **              Corrected incorrect source of opening deposit and/or opening fee
 **              to Share ID '0000' when the funding source and or fee source was a share
 **              with an alphanumeric ID (such as "ABCD")
-**  Ver. 1.4.4  02/04/24 JuCarson
+**  Ver. 1.4.4  02/04/25 JuCarson
 **              Corrected logic for dividend types using a "Fixed" rate selection in
 **              both share rate procedures.
 **
@@ -585,7 +585,7 @@ END
 
 SETUP
  PROGRAMVERSION="1.4.4"
- LASTMODDATE='02/04/24'
+ LASTMODDATE='02/04/25'
  LASTMODTIME="11:00 ET"
                       
  PROGRAMUPDATENOTE1="Corrected logic for dividend types using a fixed"
@@ -4139,3 +4139,4 @@ PROCEDURE CHECKFORINVALIDCHARS
 END [PROCEDURE]
 
 #INCLUDE "RB.LISTEXPAND"
+

--- a/open-subshare/REPWRITERSPECS/BANNO.NEWSUBCREATE.V1.POW
+++ b/open-subshare/REPWRITERSPECS/BANNO.NEWSUBCREATE.V1.POW
@@ -77,6 +77,9 @@
 **              Corrected incorrect source of opening deposit and/or opening fee
 **              to Share ID '0000' when the funding source and or fee source was a share
 **              with an alphanumeric ID (such as "ABCD")
+**  Ver. 1.4.4  02/04/24 JuCarson
+**              Corrected logic for dividend types using a "Fixed" rate selection in
+**              both share rate procedures.
 **
 **  This Banno service PowerOn allows the user to open a new
 **  share on the main account, add a joint, fund.
@@ -581,12 +584,12 @@ DEFINE
 END
 
 SETUP
- PROGRAMVERSION="1.4.3"
- LASTMODDATE='10/16/24'
- LASTMODTIME="10:30 MT"
-
- PROGRAMUPDATENOTE1="Corrected funding & fee source posting issue when source is"
- PROGRAMUPDATENOTE2="an alphanumeric ID."
+ PROGRAMVERSION="1.4.4"
+ LASTMODDATE='02/04/24'
+ LASTMODTIME="11:00 ET"
+                      
+ PROGRAMUPDATENOTE1="Corrected logic for dividend types using a fixed"
+ PROGRAMUPDATENOTE2="rate selection."
  CONFIGPROGRAMMINDATE='10/20/22'
 
 END [SETUP]
@@ -1907,8 +1910,7 @@ PROCEDURE GETSHARERATE
    IF DIVDEFINDEXOPTION=0 AND
       ((DIVDEFRATESELECT=1 AND
        DIVDEFFILLINMETHOD=1) OR
-      (DIVDEFRATESELECT=0 OR
-       DIVDEFRATESELECT=2 OR
+      (DIVDEFRATESELECT=2 OR
        DIVDEFRATESELECT=3 OR
        DIVDEFRATESELECT=4 OR
        DIVDEFRATESELECT=5 OR
@@ -2020,6 +2022,7 @@ PROCEDURE GETSHARERATE
    [FILL IN FROM SHARE DEFAULTS]
    IF (DIVDEFRATESELECT=1 AND
        DIVDEFFILLINMETHOD=0) OR
+       DIVDEFRATESELECT=0 OR
        RATEPRINTED=FALSE THEN
     DO
      RATEPRINTED=TRUE
@@ -2503,13 +2506,9 @@ PROCEDURE GETNEWSHARERATE   [CMS FIXED AND TESTED]
       DO
        RATEDONE=TRUE
       END
-     ELSE IF NEWSHAREDIVDEFRATESELECT=0 THEN   [FIXED FILL IN FROM DIV DEFINITIONS]
-      DO
-       NEWSHARERATE=GETDATARATE(GETPARAMDIVDEFRATE,NEWSHAREDIVTYPE,1)           [GET RATE FROM FIRST SLOT]
-       RATEDONE=TRUE
-      END
-     ELSE IF NEWSHAREDIVDEFRATESELECT=1 AND   [FILL IN FROM SHARE DEFAULTS]
-             NEWSHAREDIVDEFFILLINMETHOD=0 THEN
+     ELSE IF NEWSHAREDIVDEFRATESELECT=0 OR
+            (NEWSHAREDIVDEFRATESELECT=1 AND   [FILL IN FROM SHARE DEFAULTS]
+             NEWSHAREDIVDEFFILLINMETHOD=0) THEN
       DO
        NEWSHARERATE=NEWSHAREDIVRATE
        RATEDONE=TRUE
@@ -4140,4 +4139,3 @@ PROCEDURE CHECKFORINVALIDCHARS
 END [PROCEDURE]
 
 #INCLUDE "RB.LISTEXPAND"
-


### PR DESCRIPTION
When a dividend type's "Rate select" is 00 - Fixed, the PO should use the rate in defaults.