### PR TITLE
error 515 if no shares or loans

### DIFF
--- a/open-subshare/REPWRITERSPECS/BANNO.NEWSUBCREATE.V1.CONFIG
+++ b/open-subshare/REPWRITERSPECS/BANNO.NEWSUBCREATE.V1.CONFIG
@@ -54,6 +54,9 @@
 **              Added program installation date parameter setting.
 **  Ver. 1.4.1  09/06/24: JuCarson
 **              Updated help text verbiage.
+**  Ver. 1.5.0  02/26/25 RRobison
+**              Add support for error code 515 in support of: 
+**                Display error if there are no shares or loans under the member account
 **
 **  This Banno service PowerOn is to be installed for use on
 **  demand and is run from the Account Manager workspace to
@@ -151,7 +154,7 @@ DEFINE
  TOCOPENRESULTS         = NUMBER ARRAY(19)
  TOCFILECREATED         = NUMBER
  GROUPLOOP              = NUMBER
- MAXERRORCODE           = 14
+ MAXERRORCODE           = 15
  TESTERRORCODE          = NUMBER
  CONFIGPROGRAMVER       = CHARACTER
 [* TEK 03/30/23]
@@ -215,6 +218,7 @@ SETUP
  SACERRORCODEDEFAULTCHR(12)="No more shares of this type can be created"
  SACERRORCODEDEFAULTCHR(13)="Error calculating fee"
  SACERRORCODEDEFAULTCHR(14)="Error reading fee disclosure for group"
+ SACERRORCODEDEFAULTCHR(15)="No existing open Shares/Loans on the account"
 
  CALL INIT
  VALIDINPUT=FALSE
@@ -1535,6 +1539,8 @@ PROCEDURE PARSEHTML
        SACERRORCODECHR(13)=TEMPLINE
       IF TEMPCHAR="ERRORCODECHR514" THEN
        SACERRORCODECHR(14)=TEMPLINE
+      IF TEMPCHAR="ERRORCODECHR515" THEN
+       SACERRORCODECHR(15)=TEMPLINE
       IF TEMPCHAR="TESTERRORCODE" THEN
        TESTERRORCODE=VALUE(TEMPLINE)
       IF TEMPCHAR="PROGRAMINSTALLDATE" THEN
@@ -2089,6 +2095,8 @@ PROCEDURE LOADNTSUBACCTCONFIG
             SACERRORCODECHR(13)=SACLINE
            ELSE IF CHARACTERSEARCH(SACLINEPREV,"ERRORCODECHR514")>0 THEN
             SACERRORCODECHR(14)=SACLINE
+           ELSE IF CHARACTERSEARCH(SACLINEPREV,"ERRORCODECHR515")>0 THEN
+            SACERRORCODECHR(15)=SACLINE
            ELSE IF CHARACTERSEARCH(SACLINEPREV,"TESTERRORCODE")>0 THEN
             TESTERRORCODE=VALUE(SACLINE)
            ELSE IF CHARACTERSEARCH(SACLINEPREV,"SHARE TYPES")>0 THEN

--- a/open-subshare/REPWRITERSPECS/BANNO.NEWSUBCREATE.V1.POW
+++ b/open-subshare/REPWRITERSPECS/BANNO.NEWSUBCREATE.V1.POW
@@ -82,6 +82,8 @@
 **              both share rate procedures.
 **  Ver. 1.4.5  02/14/25 TKainz
 **              Reversed IRS/Share records order of creation for better error handling.
+**  Ver. 1.5.0  02/20/25 RRobison
+**              Display error of there are no shares or loans under the member account
 **
 **  This Banno service PowerOn allows the user to open a new
 **  share on the main account, add a joint, fund.
@@ -210,6 +212,7 @@ DEFINE
  RATEDONE                  = NUMBER
  GETRATEERROR              = CHARACTER
  AVAILBALMIN               = MONEY
+ ONESHARELOANFOUND         = NUMBER
 
  SACSHAREGROUP             = NUMBER
  SACSHAREGROUPNAMES        = CHARACTER ARRAY(19)
@@ -588,12 +591,12 @@ DEFINE
 END
 
 SETUP
- PROGRAMVERSION="1.4.5"
- LASTMODDATE='02/14/25'
- LASTMODTIME="16:00 MT"
+ PROGRAMVERSION="1.5.0"
+ LASTMODDATE='02/20/25'
+ LASTMODTIME="21:00 MT"
 
- PROGRAMUPDATENOTE1="Changed IRS record creation to occur before the share creation"
- PROGRAMUPDATENOTE2="Allowing for IRS rec error management"
+ PROGRAMUPDATENOTE1="New error condition when no shares or loans exist on account"
+ PROGRAMUPDATENOTE2=""
  CONFIGPROGRAMMINDATE='10/20/22'
 
 END [SETUP]
@@ -1376,6 +1379,35 @@ PROCEDURE QUALIFYMEMBER
      NEWLINE
      INELIGIBLEREASON="EXCLUDED ACCT TYPE"
      ERRORCODE=503
+     CALL ERRORHANDLER
+    END
+  END
+
+ [CHECK THE ACCOUNT TYPE]
+ IF INELIGIBLEREASON="" THEN
+  DO
+   ONESHARELOANFOUND=FALSE
+   FOR EACH SHARE
+    DO
+     ONESHARELOANFOUND=TRUE
+    END
+   UNTIL ONESHARELOANFOUND=TRUE
+
+   FOR EACH LOAN
+    DO
+     ONESHARELOANFOUND=TRUE
+    END
+   UNTIL ONESHARELOANFOUND=TRUE
+
+   IF ONESHARELOANFOUND=FALSE THEN
+    DO
+     INELIGIBLEREASON="NO SHARES OR LOANS"
+     PRINT "{"
+     NEWLINE
+     PRINT "  "+Q+"canOpenSubShare"+Q+": false,"
+     NEWLINE
+     CALL PRINTPROGRAMINFO
+     ERRORCODE=506
      CALL ERRORHANDLER
     END
   END

--- a/open-subshare/REPWRITERSPECS/BANNO.NEWSUBCREATE.V1.POW
+++ b/open-subshare/REPWRITERSPECS/BANNO.NEWSUBCREATE.V1.POW
@@ -82,8 +82,8 @@
 **              both share rate procedures.
 **  Ver. 1.4.5  02/14/25 TKainz
 **              Reversed IRS/Share records order of creation for better error handling.
-**  Ver. 1.5.0  02/20/25 RRobison
-**              Display error of there are no shares or loans under the member account
+**  Ver. 1.5.0  02/26/25 RRobison
+**              Display error if there are no shares or loans under the member account
 **
 **  This Banno service PowerOn allows the user to open a new
 **  share on the main account, add a joint, fund.
@@ -573,7 +573,7 @@ DEFINE
  CNLSEX                    = 35
  CNLDUPLICATED             = 36
 
- MAXERRORCODE              = 514
+ MAXERRORCODE              = 515
  BNOPRINTDEBUGINFODAYS     = NUMBER
  CONFIGPROGRAMVER          = CHARACTER
  CONFIGPROGRAMDATE         = DATE
@@ -592,8 +592,8 @@ END
 
 SETUP
  PROGRAMVERSION="1.5.0"
- LASTMODDATE='02/20/25'
- LASTMODTIME="21:00 MT"
+ LASTMODDATE='02/26/25'
+ LASTMODTIME="17:30 MT"
 
  PROGRAMUPDATENOTE1="New error condition when no shares or loans exist on account"
  PROGRAMUPDATENOTE2=""
@@ -1407,7 +1407,7 @@ PROCEDURE QUALIFYMEMBER
      PRINT "  "+Q+"canOpenSubShare"+Q+": false,"
      NEWLINE
      CALL PRINTPROGRAMINFO
-     ERRORCODE=506
+     ERRORCODE=515
      CALL ERRORHANDLER
     END
   END
@@ -3475,6 +3475,7 @@ PROCEDURE ERRORHANDLER
 **  512 - Maximum share limit error
 **  513 - Error calculating fee
 **  514 - Error reading fee disclosure LF for group
+**  515 - No existing open Shares/Loans on the account
 *]
 
  IF ERRORCODE>=500 AND ERRORCODE<=MAXERRORCODE THEN
@@ -4012,6 +4013,9 @@ PROCEDURE SETUPERRORCODES
 
  ERRORCODEDESCR(ECDEFAULT,14)="Error reading Share group fee disclosure file"
  ERRORCODEDESCR(ECCUSTOM,14)=""
+
+ ERRORCODEDESCR(ECDEFAULT,15)="No existing open Shares/Loans on the account"
+ ERRORCODEDESCR(ECCUSTOM,15)=""
 END [PROCEDURE]
 
 PROCEDURE GETSACFEEINFO


### PR DESCRIPTION
Updated open subshare poweron to prevent the opening of a new share when no shares or loans exist under the member account.  Error 515 is returned in this scenario.

[Jira CUS-3698](https://banno-jha.atlassian.net/browse/CUS-3698)